### PR TITLE
🔄 updated 'releases.properties' and 'build.properties', and added 'bearsampp.conf' for version 2.5.0 release removed "win-unpacked" from build.xml due to change in .zip

### DIFF
--- a/bin/bruno2.5.0/bearsampp.conf
+++ b/bin/bruno2.5.0/bearsampp.conf
@@ -1,0 +1,4 @@
+brunoVersion = "2.5.0"
+brunoExe = "Bruno.exe"
+
+#bundleRelease = "2024.9.12"

--- a/bin/bruno2.5.0/bearsampp.conf
+++ b/bin/bruno2.5.0/bearsampp.conf
@@ -1,4 +1,4 @@
 brunoVersion = "2.5.0"
-brunoExe = "Bruno.exe"
+brunoExe = "bruno.exe"
 
 #bundleRelease = "2024.9.12"

--- a/build.properties
+++ b/build.properties
@@ -1,4 +1,4 @@
 bundle.name = bruno
-bundle.release = 2025.4.18
+bundle.release = 2025.6.13
 bundle.type = tools
 bundle.format = 7z

--- a/build.xml
+++ b/build.xml
@@ -21,12 +21,12 @@
         <replaceproperty src="bundle.folder" dest="bundle.version" replace="${bundle.name}" with=""/>
 
         <getmoduleuntouched name="${bundle.name}" version="${bundle.version}" propSrcDest="bundle.srcdest" propSrcFilename="bundle.srcfilename"/>
-        <assertfile file="${bundle.srcdest}/win-unpacked/bruno.exe"/>
+        <assertfile file="${bundle.srcdest}/bruno.exe"/>
 
         <delete dir="${bundle.tmp.prep.path}/${bundle.folder}"/>
         <mkdir dir="${bundle.tmp.prep.path}/${bundle.folder}"/>
         <copy todir="${bundle.tmp.prep.path}/${bundle.folder}" overwrite="true">
-            <fileset dir="${bundle.srcdest}/win-unpacked"/>
+            <fileset dir="${bundle.srcdest}"/>
         </copy>
         <copy todir="${bundle.tmp.prep.path}/${bundle.folder}" overwrite="true">
             <fileset dir="${bundle.path}" defaultexcludes="yes"/>

--- a/releases.properties
+++ b/releases.properties
@@ -9,3 +9,4 @@
 1.38.1 = https://github.com/Bearsampp/module-bruno/releases/download/2025.2.9/bearsampp-bruno-1.38.1-2025.2.9.7z
 1.39.1 = https://github.com/Bearsampp/module-bruno/releases/download/2025.3.2/bearsampp-bruno-1.39.1-2025.3.2.7z
 2.1.0 = https://github.com/Bearsampp/module-bruno/releases/download/2025.4.18/bearsampp-bruno-2.1.0-2025.4.18.7z
+2.5.0 = https://github.com/Bearsampp/module-bruno/releases/download/2025.6.13/bearsampp-bruno-2.5.0-2025.6.13.7z


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
• Added Bruno 2.5.0 configuration and release entry
• Updated bundle release date to 2025.6.13
• Fixed build path references removing win-unpacked directory


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bearsampp.conf</strong><dd><code>Add Bruno 2.5.0 configuration file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

bin/bruno2.5.0/bearsampp.conf

• Added new configuration file for Bruno version 2.5.0<br> • Set <br>brunoVersion to "2.5.0" and brunoExe to "Bruno.exe"<br> • Included <br>commented bundleRelease property


</details>


  </td>
  <td><a href="https://github.com/Bearsampp/module-bruno/pull/8/files#diff-2c200c42ff646cb116835b8a2695a68523e7e6c8ccc9421d26f4df65be0dde44">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>build.properties</strong><dd><code>Update bundle release date</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

build.properties

• Updated bundle.release from 2025.4.18 to 2025.6.13


</details>


  </td>
  <td><a href="https://github.com/Bearsampp/module-bruno/pull/8/files#diff-e40833ed7fe7cbf5408b6b878877e7a030a56c3b0a3c724dc2c9bb2efcbe68d0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>releases.properties</strong><dd><code>Add Bruno 2.5.0 release entry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

releases.properties

• Added new release entry for Bruno 2.5.0<br> • Mapped version to download <br>URL with 2025.6.13 release date


</details>


  </td>
  <td><a href="https://github.com/Bearsampp/module-bruno/pull/8/files#diff-e6bca46c0571eef762f6438540dd9012a0432e7055b4805f2fed16ecd993b645">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build.xml</strong><dd><code>Fix build paths removing win-unpacked references</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

build.xml

• Removed "win-unpacked" directory references from build paths<br> • <br>Updated assertfile and fileset paths to use root directory


</details>


  </td>
  <td><a href="https://github.com/Bearsampp/module-bruno/pull/8/files#diff-766797f233c18114f9499750cf1ffbf3829aeea50283850619c01bd173132021">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>